### PR TITLE
Send user-agent with requests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -89,6 +89,7 @@ async fn ping_url(url: &String, timeout: u64) {
     let client = Client::builder()
         .timeout(Duration::new(timeout, 0))
         .connector(Connector::new().ssl(builder.build()).finish())
+        .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:88.0) Gecko/20100101 Firefox/88.0")
         .finish();
 
     let response = client.get(url).send().await;


### PR DESCRIPTION
This fixes 9anime always showing as offline. I went with the latest Firefox UA at the time of testing since Chrome is often used by headless browsers.